### PR TITLE
CU-86bwj1mfw-in-markdown_to_anki-if-no-notes-are-found-do-not-create-deck

### DIFF
--- a/src/markdown_to_anki.py
+++ b/src/markdown_to_anki.py
@@ -59,6 +59,10 @@ def main():
 
     print(f"Found {len(callouts)} callouts")
 
+    if(len(codeblocks) + len(callouts) == 0):
+        print("Found no notes or callouts to create a deck with. Aborting.")
+        return
+
     decks = {}
 
     assembler.add_notes_from_codeblocks(codeblocks, decks)


### PR DESCRIPTION
-  added conditional return if no codeblocks or callouts have been found